### PR TITLE
Conditionals for puppetdb version and default off for max pool size

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -28,7 +28,7 @@ class puppetdb::params inherits puppetdb::globals {
   $database_ssl           = undef
   $jdbc_ssl_properties    = ''
   $database_validate      = true
-  $database_max_pool_size = '25'
+  $database_max_pool_size = undef
 
   # These settings manage the various auto-deactivation and auto-purge settings
   $node_ttl               = '0s'
@@ -58,7 +58,7 @@ class puppetdb::params inherits puppetdb::globals {
   $read_conn_max_age                 = '60'
   $read_conn_keep_alive              = '45'
   $read_conn_lifetime                = '0'
-  $read_database_max_pool_size       = '25'
+  $read_database_max_pool_size       = undef
 
   $manage_firewall         = true
   $java_args               = {}
@@ -166,4 +166,13 @@ class puppetdb::params inherits puppetdb::globals {
   $certificate_whitelist      = [ ]
   # change to this to only allow access by the puppet master by default:
   #$certificate_whitelist      = [ $::servername ]
+
+  # Get the parameter name for the database connection pool tuning
+  if $puppetdb_version in ['latest','present'] or versioncmp($puppetdb_version, '4.0.0') >= 0 {
+    $database_max_pool_size_setting_name = 'maximum-pool-size'
+  } elsif versioncmp($puppetdb_version, '3.2.0') >= 0 {
+    $database_max_pool_size_setting_name = 'partition-conn-max'
+  } else {
+    $database_max_pool_size_setting_name = undef
+  }
 }

--- a/manifests/server/database.pp
+++ b/manifests/server/database.pp
@@ -149,8 +149,17 @@ class puppetdb::server::database (
     value   => $conn_lifetime,
   }
 
-  ini_setting { 'puppetdb_database_max_pool_size':
-    setting => 'maximum-pool-size',
-    value   => $database_max_pool_size,
+  if $puppetdb::params::database_max_pool_size_setting_name != undef {
+    if $database_max_pool_size == 'absent' {
+      ini_setting { 'puppetdb_database_max_pool_size':
+        ensure  => absent,
+        setting => $puppetdb::params::database_max_pool_size_setting_name,
+      }
+    } elsif $database_max_pool_size != undef {
+      ini_setting { 'puppetdb_database_max_pool_size':
+        setting => $puppetdb::params::database_max_pool_size_setting_name,
+        value   => $database_max_pool_size,
+      }
+    }
   }
 }

--- a/manifests/server/read_database.pp
+++ b/manifests/server/read_database.pp
@@ -127,6 +127,20 @@ class puppetdb::server::read_database (
       setting => 'conn-lifetime',
       value   => $conn_lifetime,
     }
+
+    if $puppetdb::params::database_max_pool_size_setting_name != undef {
+      if $database_max_pool_size == 'absent' {
+        ini_setting { 'puppetdb_read_database_max_pool_size':
+          ensure  => absent,
+          setting => $puppetdb::params::database_max_pool_size_setting_name,
+        }
+      } elsif $database_max_pool_size != undef {
+        ini_setting { 'puppetdb_read_database_max_pool_size':
+          setting => $puppetdb::params::database_max_pool_size_setting_name,
+          value   => $database_max_pool_size,
+        }
+      }
+    }
   } else {
     file { "${confdir}/read_database.ini":
       ensure => absent,

--- a/spec/unit/classes/server/database_ini_spec.rb
+++ b/spec/unit/classes/server/database_ini_spec.rb
@@ -118,14 +118,7 @@ describe 'puppetdb::server::database', :type => :class do
              'setting' => 'conn-lifetime',
              'value'   => '0'
              )}
-      it { should contain_ini_setting('puppetdb_database_max_pool_size').
-        with(
-             'ensure'  => 'present',
-             'path'    => '/etc/puppetlabs/puppetdb/conf.d/database.ini',
-             'section' => 'database',
-             'setting' => 'maximum-pool-size',
-             'value'   => '25'
-             )}
+      it { should_not contain_ini_setting('puppetdb_database_max_pool_size') }
     end
 
     describe 'when using a legacy PuppetDB version' do
@@ -234,14 +227,7 @@ describe 'puppetdb::server::database', :type => :class do
              'setting' => 'conn-lifetime',
              'value'   => '0'
              )}
-      it { should contain_ini_setting('puppetdb_database_max_pool_size').
-        with(
-             'ensure'  => 'present',
-             'path'    => '/etc/puppetdb/conf.d/database.ini',
-             'section' => 'database',
-             'setting' => 'maximum-pool-size',
-             'value'   => '25'
-             )}
+      it { should_not contain_ini_setting('puppetdb_database_max_pool_size') }
     end
 
     describe 'when overriding database_path for embedded' do
@@ -259,6 +245,96 @@ describe 'puppetdb::server::database', :type => :class do
              'setting' => 'subname',
              'value'   => 'file:/tmp/foo;hsqldb.tx=mvcc;sql.syntax_pgs=true'
              )}
+    end
+
+    describe 'when setting max pool size' do
+      context 'on current PuppetDB' do
+        describe 'to a numeric value' do
+          let(:params) do
+            {
+              'database_max_pool_size': 12345
+            }
+          end
+          it { should contain_ini_setting('puppetdb_database_max_pool_size').
+            with(
+              'ensure'  => 'present',
+              'path'    => '/etc/puppetlabs/puppetdb/conf.d/database.ini',
+              'section' => 'database',
+              'setting' => 'maximum-pool-size',
+              'value'   => '12345'
+            )}
+        end
+
+        describe 'to absent' do
+          let(:params) do
+            {
+              'database_max_pool_size': 'absent'
+            }
+          end
+          it { should contain_ini_setting('puppetdb_database_max_pool_size').
+            with(
+              'ensure'  => 'absent',
+              'path'    => '/etc/puppetlabs/puppetdb/conf.d/database.ini',
+              'section' => 'database',
+              'setting' => 'maximum-pool-size'
+            )}
+        end
+      end
+
+      context 'on PuppetDB 3.2' do
+        let (:pre_condition) { 'class { "puppetdb::globals": version => "3.2.0", }' }
+        describe 'to a numeric value' do
+          let(:params) do
+            {
+              'database_max_pool_size': 12345
+            }
+          end
+          it { should contain_ini_setting('puppetdb_database_max_pool_size').
+            with(
+              'ensure'  => 'present',
+              'path'    => '/etc/puppetlabs/puppetdb/conf.d/database.ini',
+              'section' => 'database',
+              'setting' => 'partition-conn-max',
+              'value'   => '12345'
+            )}
+        end
+
+        describe 'to absent' do
+          let(:params) do
+            {
+              'database_max_pool_size': 'absent'
+            }
+          end
+          it { should contain_ini_setting('puppetdb_database_max_pool_size').
+            with(
+              'ensure'  => 'absent',
+              'path'    => '/etc/puppetlabs/puppetdb/conf.d/database.ini',
+              'section' => 'database',
+              'setting' => 'partition-conn-max'
+            )}
+        end
+      end
+
+      context 'on a legacy PuppetDB version' do
+        let (:pre_condition) { 'class { "puppetdb::globals": version => "2.2.0", }' }
+        describe 'to a numeric value' do
+          let(:params) do
+            {
+              'database_max_pool_size': 12345
+            }
+          end
+          it { should_not contain_ini_setting('puppetdb_database_max_pool_size') }
+        end
+
+        describe 'to absent' do
+          let(:params) do
+            {
+              'database_max_pool_size': 'absent'
+            }
+          end
+          it { should_not contain_ini_setting('puppetdb_database_max_pool_size') }
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Hey @nward - I found your pull request over at https://github.com/puppetlabs/puppetlabs-puppetdb/pull/229 and discovered that you have already added the parameter that I was about to add! Thank you for that! 😸

There was a [comment](https://github.com/puppetlabs/puppetlabs-puppetdb/pull/229#issuecomment-217498313) suggesting that you default this to being turned off, and also add compatibility for 3.x. This PR should accomplish both of those things.

I have tested this code with PuppetDB 3.2 and it works. (I have no way to test against 4.0 but presumably you do.) Spec tests pass as well.

Hope this helps!
